### PR TITLE
Refactor data access to Entity Framework (EF6)

### DIFF
--- a/DepoYonetim.Aplication/KoliManager.cs
+++ b/DepoYonetim.Aplication/KoliManager.cs
@@ -1,16 +1,9 @@
-﻿
-
-using DepoYonetim.Application;
-using DepoYonetim.Core.Enums;
+﻿using DepoYonetim.Application;
 using DepoYonetim.DataAccess.Repostories;
 using DepoYonetim.Models.Entities;
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DepoYonetim.Aplication
 {
@@ -18,65 +11,66 @@ namespace DepoYonetim.Aplication
     {
         private readonly Repository _repository;
         private readonly UrunManager _urunManager;
-        private readonly LotUrunMenager _LotUrunMenager;
-        private readonly Uretim _Uretim;
-        public KoliManager(Repository repository) => _repository = repository;
+        private readonly LotUrunMenager _lotUrunMenager;
+        private readonly Uretim _uretim;
+
+        public KoliManager(Repository repository)
+        {
+            _repository = repository;
+            _urunManager = new UrunManager(repository);
+            _lotUrunMenager = new LotUrunMenager(repository);
+            _uretim = new Uretim(repository);
+        }
 
         public List<TblKoli> GetAllKoli()
         {
-            var request = _repository.GetByData("SELECT * FROM Tbl_Koli");
-            if ((request.dt == null) || (request._state != State.Success)) throw new Exception("Koli Bulunamadı");
-
-            var query = from koli in request.dt.AsEnumerable()
-                        select new TblKoli
-                        {
-                            Id = koli.Field<int>("Id"),
-                            KoliKodu = koli.Field<string>("KoliKodu"),
-                            UrunId = koli.Field<string>("UrunId"),
-                            LotId = koli.Field<string>("LotId"),
-                            NetAgirlik = koli.Field<string>("NetAgirlik"),
-                            OlusturmaTarih = koli.Field<DateTime>("OlusturmaTarih")
-
-                        };
-            return query.ToList();
+            return _repository.Query<TblKoli>().ToList();
         }
 
-        public string GenerateKoliKod() { return "KOL-" + Guid.NewGuid().ToString("N").Substring(0, 8).ToUpper(); }
-
-        public List<TblKoli> GetKoliByLotNo(string LotNo,string UrunKod )
+        public string GenerateKoliKod()
         {
-            string koliKod = GenerateKoliKod();
-            int urunId = _urunManager.GetUrunByUrunkod(UrunKod).ID;
-            int lotId = _LotUrunMenager.GetIdByLotNo(LotNo);
-            string netAgirlik = _Uretim.UrunConfirm(LotNo).Agirlik;
-            DateTime Date = DateTime.Now;
+            return "KOL-" + Guid.NewGuid().ToString("N").Substring(0, 8).ToUpper();
+        }
 
-            TblKoli lst = new TblKoli
+        public List<TblKoli> GetKoliByLotNo(string lotNo, string urunKod)
+        {
+            var urunId = 0;
+            if (!string.IsNullOrWhiteSpace(urunKod))
+            {
+                urunId = _urunManager.GetUrunByUrunkod(urunKod)?.ID ?? 0;
+            }
+
+            if (urunId == 0 && !string.IsNullOrWhiteSpace(lotNo))
+            {
+                urunId = _repository.Query<TblLot>()
+                    .Where(x => x.LotNo == lotNo)
+                    .Select(x => x.UrunID)
+                    .FirstOrDefault();
+            }
+
+            var lotId = !string.IsNullOrWhiteSpace(lotNo)
+                ? _lotUrunMenager.GetIdByLotNo(lotNo)
+                : _repository.Query<TblLot>().Where(x => x.UrunID == urunId && x.Status).Select(x => x.ID).FirstOrDefault();
+
+            var netAgirlik = !string.IsNullOrWhiteSpace(lotNo)
+                ? _uretim.UrunConfirm(lotNo).Agirlik
+                : _uretim.AgirlikAtama();
+
+            var koli = new TblKoli
             {
                 KoliKodu = GenerateKoliKod(),
-                UrunId = _urunManager.GetUrunByUrunkod(LotNo).ID.ToString(),
-                LotId = _LotUrunMenager.GetIdByLotNo(LotNo).ToString(),
-                NetAgirlik = _Uretim.UrunConfirm(LotNo).Agirlik,
+                UrunId = urunId.ToString(),
+                LotId = lotId.ToString(),
+                NetAgirlik = netAgirlik,
                 OlusturmaTarih = DateTime.Now
             };
 
-            return new List<TblKoli> { lst };
-
-
+            return new List<TblKoli> { koli };
         }
-        public bool KoliKayit(TblKoli dt)
+
+        public bool KoliKayit(TblKoli koli)
         {
-            string insertQuery = $"INSERT INTO Tbl_Koli (KoliKodu,UrunId,LotId,NetAgirlik,OlusturmaTarih)VALUES('{dt.KoliKodu}','{dt.UrunId}','{dt.LotId}','{dt.NetAgirlik}',{dt.OlusturmaTarih})";
-
-            var request = _repository.ExecuteSql(insertQuery, null);
-
-
-            return (request._state != State.Success) ? false : true;
+            return _repository.Add(koli).state == Core.Enums.State.Success;
         }
-
-
-
-
     }
 }
-

--- a/DepoYonetim.Aplication/KoliManager.cs
+++ b/DepoYonetim.Aplication/KoliManager.cs
@@ -37,7 +37,13 @@ namespace DepoYonetim.Aplication
             var urunId = 0;
             if (!string.IsNullOrWhiteSpace(urunKod))
             {
-                urunId = _urunManager.GetUrunByUrunkod(urunKod)?.ID ?? 0;
+                var urun = _urunManager.GetUrunByUrunkod(urunKod);
+                if (urun == null)
+                {
+                    throw new InvalidOperationException($"Geçersiz ürün kodu: {urunKod}");
+                }
+
+                urunId = urun.ID;
             }
 
             if (urunId == 0 && !string.IsNullOrWhiteSpace(lotNo))
@@ -51,6 +57,11 @@ namespace DepoYonetim.Aplication
             var lotId = !string.IsNullOrWhiteSpace(lotNo)
                 ? _lotUrunMenager.GetIdByLotNo(lotNo)
                 : _repository.Query<TblLot>().Where(x => x.UrunID == urunId && x.Status).Select(x => x.ID).FirstOrDefault();
+
+            if (urunId <= 0 || lotId <= 0)
+            {
+                throw new InvalidOperationException("Koli oluşturmak için geçerli ürün ve lot bilgisi gereklidir.");
+            }
 
             var netAgirlik = !string.IsNullOrWhiteSpace(lotNo)
                 ? _uretim.UrunConfirm(lotNo).Agirlik

--- a/DepoYonetim.Aplication/LotUrunMenager.cs
+++ b/DepoYonetim.Aplication/LotUrunMenager.cs
@@ -1,15 +1,9 @@
 ﻿using DepoYonetim.DataAccess.Repostories;
+using DepoYonetim.Models.Entities;
+using DepoYonetim.Models.Entities.Urun;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Data;
-using DepoYonetim.Models.Entities;
-using DepoYonetim.Models.Entities.Urun;
-using DepoYonetim.Core.Enums;
-using System.Security.Cryptography.X509Certificates;
-using System.Runtime.InteropServices.WindowsRuntime;
 
 namespace DepoYonetim.Application
 {
@@ -18,164 +12,87 @@ namespace DepoYonetim.Application
         private readonly Repository _repository;
         public LotUrunMenager(Repository repository) => _repository = repository;
 
-        // LotUrun class contains properties from both Tbl_Lot and Tbl_Urun
-        // Example: LotUrun has properties like LotNo, UrunAdi, UrunKod, etc.
-        // You need to create LotUrun class in Models/Entities/Urun folder
         public List<LotUrun> GetAllLotUrun()
         {
-            // Retrieve lot data
+            var lotlar = _repository.Query<TblLot>();
+            var urunler = _repository.Query<TblUrun>();
 
-
-            var request_Lot = _repository.GetByData("SELECT * FROM Tbl_Lot");
-
-            // Check if the data retrieval was failed
-            if (request_Lot._state != Core.Enums.State.Success) throw new Exception("Lot verileri alınamadı: " + request_Lot.message);
-
-            // Retrieve product data
-            var request_Urun = _repository.GetByData("SELECT * FROM Tbl_Urun");
-            // Check if the data retrieval was failed
-            if (request_Urun._state != Core.Enums.State.Success) throw new Exception("Ürün verileri alınamadı: " + request_Urun.message);
-
-
-            // Join product and lot data
-
-            var query = from lot in request_Lot.dt.AsEnumerable()
-                        join urun in request_Urun.dt.AsEnumerable()
-                        on lot.Field<int>("UrunID") equals urun.Field<int>("ID")
-                        // Project the result into UrunLot objects
-                        select new LotUrun
-                        {
-                            // Example properties (you need to adjust according to actual properties)
-                            ID = lot.Field<int>("ID"),
-                            UrunAdi = urun.Field<string>("UrunAdi"),
-                            UrunKod = urun.Field<string>("UrunKod"),
-                            LotKodu = lot.Field<string>("LotNo"),
-                            Status = lot.Field<bool?>("Status") ?? false
-
-                        };
-
-            // Return the result as a list
-            return query.ToList();
+            return (from lot in lotlar
+                    join urun in urunler on lot.UrunID equals urun.ID
+                    select new LotUrun
+                    {
+                        ID = lot.ID,
+                        UrunAdi = urun.UrunAdi,
+                        UrunKod = urun.UrunKod,
+                        LotKodu = lot.LotNo,
+                        Status = lot.Status
+                    }).ToList();
         }
-        //ürün adına göre ürün getir
+
         public TblUrun GetUrunByUrunName(string urunName)
         {
-            try
-            {
-                var request_Urun = _repository.GetByData($"SELECT * FROM Tbl_Urun WHERE UrunAdi = '{urunName}'");
-                if (request_Urun._state != State.Success) throw new Exception("Ürün verileri alınamadı: " + request_Urun.message);
-                var UrunRow = request_Urun.dt.AsEnumerable().FirstOrDefault();
-                if (UrunRow == null) throw new Exception("Belirtilen Ürün bulunamadı.");
-                return new TblUrun
-                {
-                    ID = UrunRow.Field<int>("ID"),
-                    UrunKod = UrunRow.Field<string>("UrunKod"),
-                    UrunAdi = UrunRow.Field<string>("UrunAdi")
-                };
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-                return null;
-            }
-        }
-        //Tüm ürünleri listele
-        public List<TblUrun> GetAllUrun()
-        {
-            var _request_Urun = _repository.GetByData("SELECT * FROM Tbl_Urun");
-            if (_request_Urun._state != State.Success) throw new Exception("Ürün verileri alınamadı: " + _request_Urun.message);
-            var urunList = _request_Urun.dt.AsEnumerable().Select(row => new TblUrun
-            {
-                ID = row.Field<int>("ID"),
-                UrunKod = row.Field<string>("UrunKod"),
-                UrunAdi = row.Field<string>("UrunAdi"),
-                Status = row.Field<bool>("Status")
-            });
-            return urunList.ToList();
+            return _repository.Query<TblUrun>().FirstOrDefault(x => x.UrunAdi == urunName);
         }
 
+        public List<TblUrun> GetAllUrun()
+        {
+            return _repository.Query<TblUrun>().ToList();
+        }
 
         public TblLot GetLotByID(int id)
         {
-            var request_Lot = _repository.GetByData($"SELECT * FROM Tbl_Lot WHERE ID = {id}");
-            if (request_Lot._state != State.Success) throw new Exception("Lot verileri alınamadı: " + request_Lot.message);
-            var LotRow = request_Lot.dt.AsEnumerable().FirstOrDefault();
-            if (LotRow == null) throw new Exception("Belirtilen Lot bulunamadı.");
-            return new TblLot
-            {
-                ID = LotRow.Field<int>("ID"),
-                LotNo = LotRow.Field<string>("LotNo"),
-                UrunID = LotRow.Field<int>("UrunID"),
-                Status = LotRow.Field<bool>("Status")
-            };
+            return _repository.Query<TblLot>().FirstOrDefault(x => x.ID == id);
         }
 
-        public int GetIdByLotNo(string pLotNo)
+        public int GetIdByLotNo(string lotNo)
         {
-            var request_Lot = _repository.GetByData($"SELECT ID FROM Tbl_Lot WHERE LotNo = '{pLotNo}' and Status = 1");
-            if (request_Lot._state != State.Success) throw new Exception("Lot verileri alınamadı: " + request_Lot.message);
-            var LotRow = request_Lot.dt.AsEnumerable().FirstOrDefault();
-            if (LotRow == null) throw new Exception("Belirtilen Lot bulunamadı.");
-            return LotRow.Field<int>("ID");
+            var lot = _repository.Query<TblLot>().FirstOrDefault(x => x.LotNo == lotNo && x.Status);
+            if (lot == null) throw new Exception("Belirtilen Lot bulunamadı.");
+            return lot.ID;
         }
 
-        public bool ExistUrunId(string pLotNo, int pUrunId)
+        public bool ExistUrunId(string lotNo, int urunId)
         {
-            var request_Urun = _repository.GetByData($"SELECT * FROM [DepoYonetimi].[dbo].[Tbl_Lot] where LotNo='{pLotNo}' and  UrunID={pUrunId} and Status = 1 ");
-            if (request_Urun._state != State.Success) throw new Exception("Lot verileri alınamadı: " + request_Urun.message);
-            var LotRow = request_Urun.dt.AsEnumerable().FirstOrDefault();
-            if (LotRow == null) return false;
-            return true;
+            return _repository.Query<TblLot>().Any(x => x.LotNo == lotNo && x.UrunID == urunId && x.Status);
         }
 
         public bool LotKaydet(TblLot lot)
         {
-            string insertQuery = $"INSERT INTO Tbl_Lot (LotNo,UrunID,Status) VALUES ('{lot.LotNo}','{lot.UrunID}','{1}')";
-            var result = _repository.ExecuteSql(insertQuery, null);
-            bool Ret = State.Success == result._state ? true : false;
-            return Ret;
+            lot.Status = true;
+            return _repository.Add(lot).state == Core.Enums.State.Success;
         }
-        //lot id ye göre lot getir Kontrol Amaclı
-        public TblLot GetLotById(int LotId)
+
+        public TblLot GetLotById(int lotId)
         {
-            var request_Lot = _repository.GetByData($"SELECT * FROM Tbl_Lot WHERE ID = {LotId}");
-            if (request_Lot._state != State.Success) throw new Exception("Lot verileri alınamadı: " + request_Lot.message);
-
-            var LotRow = request_Lot.dt.AsEnumerable().FirstOrDefault();
-
-            if (LotRow == null) throw new Exception("Belirtilen Lot bulunamadı.");
-            return new TblLot
-            {
-                ID = LotRow.Field<int>("ID"),
-                LotNo = LotRow.Field<string>("LotNo"),
-                UrunID = LotRow.Field<int>("UrunID"),
-                Status = LotRow.Field<bool>("Status")
-            };
+            return _repository.Query<TblLot>().FirstOrDefault(x => x.ID == lotId);
         }
-
 
         public bool LotGuncelle(TblLot lot)
         {
-            string updateQuery = $"UPDATE Tbl_Lot SET LotNo = '{lot.LotNo}', UrunID = '{lot.UrunID}',Status = '{lot.Status}' WHERE ID = {lot.ID}";
-            var result = _repository.ExecuteSql(updateQuery, null);
-            if (result._state != State.Success) throw new Exception("lot güncellenemedi: " + result.message);
-            else return true;
+            var current = GetLotById(lot.ID);
+            if (current == null) return false;
+
+            current.LotNo = lot.LotNo;
+            current.UrunID = lot.UrunID;
+            current.Status = lot.Status;
+
+            return _repository.Update(current).state == Core.Enums.State.Success;
         }
 
-        public bool LotSoftSil(int LotId)
+        public bool LotSoftSil(int lotId)
         {
-            string deleteQuery = $"UPDATE Tbl_Lot SET Status = 0 WHERE ID = {LotId}";
-            var result = _repository.ExecuteSql(deleteQuery, null);
-            if (result._state != State.Success) throw new Exception("Lot silinemedi: " + result.message);
-            else return true;
+            var current = GetLotById(lotId);
+            if (current == null) return false;
+
+            current.Status = false;
+            return _repository.Update(current).state == Core.Enums.State.Success;
         }
 
         public bool LotKaliciSil(int lotId)
         {
-            string deleteQuery = $"DELETE FROM Tbl_Lot WHERE ID = {lotId}";
-            var result = _repository.ExecuteSql(deleteQuery, null);
-            if (result._state != State.Success) throw new Exception("Lot silinemedi: " + result.message);
-            else return true;
+            var current = GetLotById(lotId);
+            if (current == null) return false;
+            return _repository.Delete(current).state == Core.Enums.State.Success;
         }
     }
 }

--- a/DepoYonetim.Aplication/PersonelRolMenager.cs
+++ b/DepoYonetim.Aplication/PersonelRolMenager.cs
@@ -1,12 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DepoYonetim.DataAccess.Repostories;
 using DepoYonetim.Models.Entities;
-using DepoYonetim.Core.Enums;
 
 namespace DepoYonetim.Application
 {
@@ -15,192 +11,79 @@ namespace DepoYonetim.Application
         private readonly Repository _repository;
         public PersonelRolMenager(Repository repository) => _repository = repository;
 
-        // Get all personnel with their roles
         public List<PersonelRol> GetAllPersonelRol()
         {
             try
             {
-                // Retrieve user data
-                var request_Kullanici = _repository.GetByData("SELECT * FROM Tbl_Kullanici");
+                var kullanicilar = _repository.Query<TblKullanici>();
+                var roller = _repository.Query<TblRole>();
 
-                // Check if the data retrieval was failed
-                if (request_Kullanici._state != State.Success) throw new Exception("Kullanıcı verileri alınamadı: " + request_Kullanici.message);
-
-                // Retrieve role data
-                var request_Rol = _repository.GetByData("SELECT * FROM Tbl_Role");
-
-                // Check if the data retrieval was failed
-                if (request_Rol._state != State.Success) throw new Exception("Rol verileri alınamadı: " + request_Rol.message);
-
-                // Join user and role data
-
-                var query = from kullanici in request_Kullanici.dt.AsEnumerable()
-                            join rol in request_Rol.dt.AsEnumerable()
-                            on kullanici.Field<int>("RoleID") equals rol.Field<int>("ID")
-                            // Project the result into PersonelRol objects
-                            select new PersonelRol
-                            {
-                                ID = kullanici.Field<int>("Id"),
-                                AdSoyad = kullanici.Field<string>("AdSoyad"),
-                                KullaniciAdi = kullanici.Field<string>("KullaniciAdi"),
-                                SifreHash = kullanici.Field<string>("SifreHash"),
-                                RoleName = rol.Field<string>("RoleName"),
-                                Status = kullanici.Field<bool>("Status")
-                            };
-                #region Alternatif
-
-                //var query = request_Kullanici.dt.AsEnumerable()
-                //  .Join(
-                //        request_Rol.dt.AsEnumerable(),
-                //        kullanici => kullanici.Field<int>("RoleId"),
-                //        rol => rol.Field<int>("Id"),
-                //         (kullanici, rol) => new PersonelRol
-                //         {
-                //             ID = kullanici.Field<int>("Id"),
-                //             AdSoyad = kullanici.Field<string>("AdSoyad"),
-                //             KullaniciAdi = kullanici.Field<string>("KullaniciAdi"),
-                //             SifreHash = kullanici.Field<string>("SifreHash"),
-                //             RoleName = rol.Field<string>("RoleName"),
-                //             Status = kullanici.Field<bool>("Status")
-                //         }
-                //        ).ToList();
-                #endregion
-
-                #region Alternatif
-                //foreach (DataRow item in request_Kullanici.dt.Rows)
-                //{
-                //    item["SifreHash"] = "********";
-                //    item.["KullaniciAdi"] = item["KullaniciAdi"].ToString();]
-                //} 
-                #endregion
-                // Return the result as a list
-                return query.ToList();
+                return (from kullanici in kullanicilar
+                        join rol in roller on kullanici.RoleID equals rol.ID
+                        select new PersonelRol
+                        {
+                            ID = kullanici.ID,
+                            AdSoyad = kullanici.AdSoyad,
+                            KullaniciAdi = kullanici.KullaniciAdi,
+                            SifreHash = kullanici.SifreHash,
+                            RoleName = rol.RoleName,
+                            Status = kullanici.Status
+                        }).ToList();
             }
             catch (Exception ex)
             {
-                // Burada log da atabilirsin
                 throw new Exception("Personel-Rol listesi oluşturulurken hata oluştu.", ex);
             }
         }
 
-        // Get role by role name
         public TblRole GetRoleByRoleName(string roleName)
         {
-            var request_Rol = _repository.GetByData($"SELECT * FROM Tbl_Role WHERE RoleName = '{roleName}'");
-
-            // Check if the data retrieval was failed
-            if (request_Rol._state != State.Success) throw new Exception("Rol verileri alınamadı: " + request_Rol.message);
-
-            // Get the first matching role
-            var rolRow = request_Rol.dt.AsEnumerable().FirstOrDefault();
-
-            // If no matching role is found, throw an exception
-            if (rolRow == null) throw new Exception("Belirtilen rol bulunamadı.");
-
-            // Map the DataRow to TblRole object and return
-
-            return new TblRole
-            {
-                ID = rolRow.Field<int>("ID"),
-                RoleName = rolRow.Field<string>("RoleName"),
-                Explanation = rolRow.Field<string>("Explanation")
-            };
+            var role = _repository.Query<TblRole>().FirstOrDefault(x => x.RoleName == roleName);
+            if (role == null) throw new Exception("Belirtilen rol bulunamadı.");
+            return role;
         }
-        // Get all roles
+
         public List<TblRole> GetAllRoles()
         {
-            var request_Rol = _repository.GetByData("SELECT * FROM Tbl_Role");
-            if (request_Rol._state != State.Success) throw new Exception("Rol verileri alınamadı: " + request_Rol.message);
-
-            // Map DataTable rows to TblRole objects
-            var roles = request_Rol.dt.AsEnumerable().Select(rolRow =>
-            new TblRole
-            {
-                ID = rolRow.Field<int>("ID"),
-                RoleName = rolRow.Field<string>("RoleName"),
-                Explanation = rolRow.Field<string>("Explanation")
-            }).ToList();
-            return roles;
+            return _repository.Query<TblRole>().ToList();
         }
-        // Add new personnel
+
         public bool PersonelKaydet(TblKullanici tblKullanici)
         {
-            string insertQuery = $"INSERT INTO Tbl_Kullanici (AdSoyad, KullaniciAdi, SifreHash, RoleID, Status) " +
-                                 $"VALUES ('{tblKullanici.AdSoyad}', '{tblKullanici.KullaniciAdi}', '{tblKullanici.SifreHash}', {tblKullanici.RoleID}, {1})";
-            var result = _repository.ExecuteSql(insertQuery, null);
-            if (result._state != State.Success)
-            {
-                return false;
-            }
-            return true;
+            tblKullanici.Status = true;
+            return _repository.Add(tblKullanici).state == Core.Enums.State.Success;
         }
-        // Get personnel by ID
+
         public TblKullanici GetPersonelById(int personelId)
         {
-            // Retrieve user data
-            var request_Kullanici = _repository.GetByData($"SELECT * FROM Tbl_Kullanici WHERE ID = {personelId}");
-
-            // Check if the data retrieval was failed
-            if (request_Kullanici._state != State.Success) throw new Exception("Kullanıcı verileri alınamadı: " + request_Kullanici.message);
-
-            // Get the first matching user
-            var kullaniciRow = request_Kullanici.dt.AsEnumerable().FirstOrDefault();
-
-            // If no matching user is found, throw an exception
-            if (kullaniciRow == null) throw new Exception("Belirtilen kullanıcı bulunamadı.");
-
-            // Map the DataRow to TblKullanici object and return
-            return new TblKullanici
-            {
-                ID = kullaniciRow.Field<int>("ID"),
-                AdSoyad = kullaniciRow.Field<string>("AdSoyad"),
-                KullaniciAdi = kullaniciRow.Field<string>("KullaniciAdi"),
-                SifreHash = kullaniciRow.Field<string>("SifreHash"),
-                RoleID = kullaniciRow.Field<int>("RoleID"),
-                Status = kullaniciRow.Field<bool>("Status")
-            };
+            var user = _repository.Query<TblKullanici>().FirstOrDefault(x => x.ID == personelId);
+            if (user == null) throw new Exception("Belirtilen kullanıcı bulunamadı.");
+            return user;
         }
 
-        // Update personnel
         public bool PersonelGuncelle(TblKullanici tblKullanici)
         {
-            string updateQuery = $"UPDATE Tbl_Kullanici SET " +
-                                 $"AdSoyad = '{tblKullanici.AdSoyad}', " +
-                                 $"KullaniciAdi = '{tblKullanici.KullaniciAdi}', " +
-                                 $"SifreHash = '{tblKullanici.SifreHash}', " +
-                                 $"RoleID = {tblKullanici.RoleID}, " +
-                                 $"Status = {(tblKullanici.Status ? 1 : 0)} " +
-                                 $"WHERE ID = {tblKullanici.ID}";
-            var result = _repository.ExecuteSql(updateQuery, null);
-            if (result._state != State.Success)
-            {
-                return false;
-            }
-            return true;
+            var current = GetPersonelById(tblKullanici.ID);
+            current.AdSoyad = tblKullanici.AdSoyad;
+            current.KullaniciAdi = tblKullanici.KullaniciAdi;
+            current.SifreHash = tblKullanici.SifreHash;
+            current.RoleID = tblKullanici.RoleID;
+            current.Status = tblKullanici.Status;
+
+            return _repository.Update(current).state == Core.Enums.State.Success;
         }
 
-        // Soft delete personnel
         public bool PersonelSoftSil(int personelId)
         {
-            string updateQuery = $"UPDATE Tbl_Kullanici SET Status = 0 WHERE ID = {personelId}";
-            var result = _repository.ExecuteSql(updateQuery, null);
-            if (result._state != State.Success)
-            {
-                return false;
-            }
-            return true;
+            var current = GetPersonelById(personelId);
+            current.Status = false;
+            return _repository.Update(current).state == Core.Enums.State.Success;
         }
 
-        // Hard delete personnel
         public bool PersonelKaldir(int personelId)
         {
-            string deleteQuery = $"DELETE FROM Tbl_Kullanici WHERE ID = {personelId}";
-            var result = _repository.ExecuteSql(deleteQuery, null);
-            if (result._state != State.Success)
-            {
-                return false;
-            }
-            return true;
+            var current = GetPersonelById(personelId);
+            return _repository.Delete(current).state == Core.Enums.State.Success;
         }
     }
 }

--- a/DepoYonetim.DataAccess/DepoYonetim.DataAccess.csproj
+++ b/DepoYonetim.DataAccess/DepoYonetim.DataAccess.csproj
@@ -31,24 +31,35 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework">
+      <HintPath>..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.Entity" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DepoYonetimDbContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repostories\Repository.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DepoYonetim.Core\DepoYonetim.Core.csproj">
       <Project>{82248b43-9d90-4863-a6f5-331a07fe5244}</Project>
       <Name>DepoYonetim.Core</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\DepoYonetim.Models\DepoYonetim.Models.csproj">
+      <Project>{1A22CD1C-9330-40C9-8C3E-B7B243F64389}</Project>
+      <Name>DepoYonetim.Models</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/DepoYonetim.DataAccess/DepoYonetimDbContext.cs
+++ b/DepoYonetim.DataAccess/DepoYonetimDbContext.cs
@@ -1,0 +1,29 @@
+﻿using System.Data.Entity;
+using DepoYonetim.Models.Entities;
+
+namespace DepoYonetim.DataAccess
+{
+    public class DepoYonetimDbContext : DbContext
+    {
+        public DepoYonetimDbContext(string connectionString) : base(connectionString)
+        {
+        }
+
+        public DbSet<TblUrun> Urunler { get; set; }
+        public DbSet<TblLot> Lotlar { get; set; }
+        public DbSet<TblKoli> Koliler { get; set; }
+        public DbSet<TblKullanici> Kullanicilar { get; set; }
+        public DbSet<TblRole> Roller { get; set; }
+
+        protected override void OnModelCreating(DbModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TblUrun>().ToTable("Tbl_Urun").HasKey(x => x.ID);
+            modelBuilder.Entity<TblLot>().ToTable("Tbl_Lot").HasKey(x => x.ID);
+            modelBuilder.Entity<TblKoli>().ToTable("Tbl_Koli").HasKey(x => x.Id);
+            modelBuilder.Entity<TblKullanici>().ToTable("Tbl_Kullanici").HasKey(x => x.ID);
+            modelBuilder.Entity<TblRole>().ToTable("Tbl_Role").HasKey(x => x.ID);
+
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/DepoYonetim.DataAccess/Repostories/Repository.cs
+++ b/DepoYonetim.DataAccess/Repostories/Repository.cs
@@ -1,135 +1,74 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Data;
+using System.Data.Entity;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using DepoYonetim.Core.Enums;
-using System.Data.SqlClient;
 
 namespace DepoYonetim.DataAccess.Repostories
 {
-    public class Repository
-    {// Veritabanı bağlantı cümlesini tutan değişken
-        private readonly string _conString;
+    public class Repository : IDisposable
+    {
+        private readonly DepoYonetimDbContext _context;
 
-        // Constructor - Repository sınıfı oluşturulduğunda bağlantı cümlesi atanır
-        public Repository(string conString) => _conString = conString;        
-        
-        /// <summary>
-        /// Verilen SQL sorgusuna göre veritabanından veri çeker ve DataTable olarak döner
-        /// </summary>
-        /// <param name="sqlQuery">SELECT tipi SQL sorgusu</param>
-        /// <returns>DataTable, işlem durumu, mesaj</returns>
-        public (DataTable dt, State _state, string message) GetByData(string sqlQuery)
+        public Repository(string conString)
+        {
+            _context = new DepoYonetimDbContext(conString);
+        }
+
+        public IQueryable<T> Query<T>() where T : class
+        {
+            return _context.Set<T>();
+        }
+
+        public T GetById<T>(int id) where T : class
+        {
+            return _context.Set<T>().Find(id);
+        }
+
+        public (bool success, State state, string message) Add<T>(T entity) where T : class
         {
             try
             {
-                // Gelen veri burada tutulacak
-                DataTable dt = new DataTable();
-
-                // SqlConnection : Veritabanı bağlantısını temsil eder
-                using (SqlConnection conn = new SqlConnection(_conString))
-                {
-                    // SqlCommand : Çalıştırılacak SQL komutunu ve bağlantıyı tutar
-                    using (SqlCommand command = new SqlCommand(sqlQuery, conn))
-                    {
-                        // SqlDataAdapter : SQL sonucunu DataTable'a doldurur
-                        SqlDataAdapter da = new SqlDataAdapter(command);
-
-                        // Bağlantıyı açmaya gerek yok. SqlDataAdapter Fill sırasında açıp kapatır
-                        da.Fill(dt);
-                    }
-                }
-
-                // Veri başarılı çekildiyse durumu Success olarak döner
-                return (dt, State.Success, "Success");
+                _context.Set<T>().Add(entity);
+                _context.SaveChanges();
+                return (true, State.Success, "Success");
             }
             catch (Exception ex)
             {
-                // Hata alındığında boş tablo döner ve hata mesajını iletir
-                return (new DataTable(), State.Fail, ex.Message);
+                return (false, State.Fail, ex.Message);
             }
         }
 
-        /// <summary>
-        /// Verilen tablo adı ve Id değerine göre tek bir kayıt döner
-        /// </summary>
-        /// <param name="tableName">Sorgulanacak tablo adı</param>
-        /// <param name="id">Filtrelenecek Id bilgisi</param>
-        /// <returns>DataRow, işlem durumu, mesaj</returns>
-        public (DataRow row, State _state, string messge) GetById(string tableName, int id)
+        public (bool success, State state, string message) Update<T>(T entity) where T : class
         {
             try
             {
-                DataTable dt = new DataTable();
-
-                using (SqlConnection conn = new SqlConnection(_conString))
-                {
-                    // Parametreli SQL komutu oluşturuldu (SQL Injection riskini azaltır)
-                    string query = $"SELECT * FROM {tableName} WHERE Id=@Id";
-
-                    using (SqlCommand cmd = new SqlCommand(query, conn))
-                    {
-                        // Parametre değeri atanıyor
-                        cmd.Parameters.AddWithValue("@Id", id);
-
-                        SqlDataAdapter da = new SqlDataAdapter(cmd);
-                        da.Fill(dt);
-                    }
-                }
-
-                // Eğer veri bulunduysa ilk satır döndürülür
-                if (dt.Rows.Count > 0)
-                    return (dt.Rows[0], State.Success, "Success");
-
-                // Hiç kayıt bulunmadıysa NotFound döner
-                return (null, State.NotFound, "Not Found");
+                _context.Entry(entity).State = EntityState.Modified;
+                _context.SaveChanges();
+                return (true, State.Success, "Success");
             }
             catch (Exception ex)
             {
-                // Hata olduğunda Fail döner
-                return (null, State.Fail, ex.Message);
+                return (false, State.Fail, ex.Message);
             }
         }
-        /// <summary>
-        /// Insert, Update veya Delete gibi etkilenecek satır döndüren SQL komutlarını çalıştırır
-        /// </summary>
-        /// <param name="sqlQuery">İşlem yapılacak SQL komutu</param>
-        /// <param name="parameters">Komutta kullanılacak parametreler</param>
-        /// <returns>Başarılı mı?, işlem durumu, mesaj</returns>
-        public (bool success, State _state, string message) ExecuteSql(string sqlQuery, SqlParameter[] parameters)
+
+        public (bool success, State state, string message) Delete<T>(T entity) where T : class
         {
             try
             {
-                using (SqlConnection conn = new SqlConnection(_conString))
-                using (SqlCommand cmd = new SqlCommand(sqlQuery, conn))
-                {
-                    // Eğer parametre varsa komuta ekleniyor
-                    if (parameters != null)
-                        cmd.Parameters.AddRange(parameters);
-
-                    // Komut çalıştırılmadan önce bağlantı açılması gerekir
-                    conn.Open();
-
-                    // ExecuteNonQuery : Etkilenen satır sayısını döndürür
-                    int result = cmd.ExecuteNonQuery();
-
-                    // İşlem sonucu kontrol edilir
-                    if (result > 0)
-                        return (true, State.Success, "Success");
-                    else
-                        return (false, State.NoRowsAffected, "No rows affected");
-                }
+                _context.Set<T>().Remove(entity);
+                _context.SaveChanges();
+                return (true, State.Success, "Success");
             }
             catch (Exception ex)
             {
-                // Hata durumunda Fail döner ve hata mesajı iletilir
-                return (false, State.Fail, "Error: " + ex.Message);
+                return (false, State.Fail, ex.Message);
             }
         }
 
-
-
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
     }
 }

--- a/DepoYonetim.DataAccess/packages.config
+++ b/DepoYonetim.DataAccess/packages.config
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EntityFramework" version="6.4.4" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
### Motivation
- Replace fragile, string-based SQL/DataTable access with Entity Framework to enable strongly-typed LINQ queries and centralized CRUD behavior.
- Simplify managers and reduce SQL injection/formatting risk by using a single EF-backed repository and entity models.

### Description
- Added `DepoYonetimDbContext` with `DbSet` mappings and table configuration for `Tbl_Urun`, `Tbl_Lot`, `Tbl_Koli`, `Tbl_Kullanici`, and `Tbl_Role` (`DepoYonetim.DataAccess/DepoYonetimDbContext.cs`).
- Replaced the old ADO.NET `Repository` with an EF-backed generic repository implementing `Query<T>`, `GetById<T>`, `Add<T>`, `Update<T>`, `Delete<T>` and `IDisposable` (`DepoYonetim.DataAccess/Repostories/Repository.cs`).
- Refactored application managers (`UrunManager`, `LotUrunMenager`, `PersonelRolMenager`, `Uretim`, `KoliManager`) to use LINQ over the EF repository instead of raw SQL strings while preserving public method signatures (`DepoYonetim.Aplication/*.cs`).
- Updated DataAccess project to reference `EntityFramework` and added `DepoYonetim.DataAccess/packages.config` with `EntityFramework 6.4.4` and adjusted the `.csproj` to include the new files.

### Testing
- Ran `nuget restore DepoYonetim.sln` which failed because `nuget` is not available in the environment (`command not found`).
- Ran `msbuild DepoYonetim.sln /t:Build /p:Configuration=Debug` which failed because `msbuild` is not available in the environment (`command not found`).
- Ran `dotnet --version` which failed because `dotnet` is not available in the environment (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992f6421098833197296b2a05b9bd8f)